### PR TITLE
Removed auto-removal of conda curl

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,9 +34,6 @@
 - name: conda updates
   command: /opt/miniconda/bin/conda update -y --all
 
-- name: remove conda-curl since it conflicts with the system curl
-  command: /opt/miniconda/bin/conda remove -y curl
-  
 - name: make system default python etc...
   when: miniconda_make_sys_default
   copy: >-


### PR DESCRIPTION
As it is, this role only runs if the user specifies installation of curl, so having the removal of conda curl in by default makes no sense. Plus, if a user has explicitly specified that curl be installed with conda, they probably don't want it removed automatically, conflicts or no. As such, there is no circumstance in which this task is a good idea.