### PR TITLE
Check for conda curl before attempting uninstall

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,10 @@ miniconda_checksums:
 miniconda_timeout_seconds: 600
 
 # add the miniconda python onto the front of the path.
-# Caveat Emptor: if your
+#
+# Caveat Emptor: you will encounter conflicts if your system package manager
+#                requires a different version of Python than this miniconda
+#                installation e.g. different major version of Pythonl.
 miniconda_make_sys_default : False
 
 miniconda_parent_dir: /usr/local

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,6 @@
   changed_when: false
   register: miniconda_conda_binary
 
-- name: check for installation of conda curl
-  become: '{{miniconda_escalate}}'
-  shell: '{{miniconda_conda_bin}} list -f curl | grep curl'
-  ignore_errors: True
-  register: miniconda_curl_exists
-
 - when: not miniconda_conda_binary.stat.exists
   block:
     - name: download installer...
@@ -53,6 +47,12 @@
   become_user: root
   when: miniconda_pkg_update
   command: '{{miniconda_conda_bin}} update -y --all'
+
+- name: check for installation of conda curl
+  become: '{{miniconda_escalate}}'
+  shell: '{{miniconda_conda_bin}} list -f curl | grep curl'
+  ignore_errors: True
+  register: miniconda_curl_exists
 
 - name: remove conda-curl since it conflicts with the system curl
   become: '{{miniconda_escalate}}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,12 @@
   changed_when: false
   register: miniconda_conda_binary
 
+- name: check for installation of conda curl
+  become: '{{miniconda_escalate}}'
+  shell: '{{miniconda_conda_bin}} list -f curl | grep curl'
+  ignore_errors: True
+  register: miniconda_curl_exists
+
 - when: not miniconda_conda_binary.stat.exists
   block:
     - name: download installer...
@@ -54,6 +60,7 @@
   command: '{{miniconda_conda_bin}} remove -y curl'
   args:
     removes: '{{miniconda_link_dir}}/lib/libcurl.a'
+  when: miniconda_curl_exists is success
 
 - name: make system default python etc...
   when: miniconda_make_sys_default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
   shell: '{{miniconda_conda_bin}} list -f curl | grep curl'
   ignore_errors: True
   register: miniconda_curl_exists
+  when: miniconda_conda_binary.stat.exists
 
 - name: remove conda-curl since it conflicts with the system curl
   become: '{{miniconda_escalate}}'


### PR DESCRIPTION
Closes #7 and #8.

This PR implements a check for the existence for conda curl before attempting removal. Attempting to remove conda curl if it does not exist creates an error and causes this role to not be idempotent:

```bash
$ conda remove curl
Solving environment: failed

PackagesNotFoundError: The following packages are missing from the target environment:
  - curl

$ echo $?
1
```