### PR TITLE
Don't directly execute installer under /tmp

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     - name: installing....
       become: '{{miniconda_escalate}}'
       become_user: root
-      command: /tmp/{{miniconda_installer_sh}} -b -p {{miniconda_install_dir}}
+      command: bash /tmp/{{miniconda_installer_sh}} -b -p {{miniconda_install_dir}}
       args:
         creates: '{{miniconda_install_dir}}'
 


### PR DESCRIPTION
For systems that don't allow execution of files under the `/tmp` directory, the only way to run the installer is to execute Bash itself and have read and execute the installer file.