### PR TITLE
Only remove conda-curl when system default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
   command: '{{miniconda_conda_bin}} update -y --all'
 
 - name: remove conda-curl since it conflicts with the system curl
+  when: miniconda_make_sys_default
   become: yes
   become_user: root
   conda:


### PR DESCRIPTION
I believe conda-curl interfering with system curl only happens when
conda is made the system default

When attempting to use this role without root, I can set
miniconda_escalate to False, but the removal of conda-curl still tries
to exectue, creating an error.