### PR TITLE
version update + add option to disable autoupdate of conda and deps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 miniconda_mirror: https://repo.continuum.io/miniconda
 miniconda_python_ver: 3
 
-miniconda_ver: '4.6.14'
+miniconda_ver: '4.7.12'
 # https://repo.continuum.io/miniconda/
 miniconda_checksums:
   Miniconda2-4.2.12-Linux-x86_64.sh: md5:c8b836baaa4ff89192947e4b1a70b07e
@@ -38,7 +38,10 @@ miniconda_checksums:
   Miniconda3-4.6.14-Linux-x86_64.sh: md5:718259965f234088d785cad1fbd7de03
   Miniconda2-4.6.14-MacOSX-x86_64.sh: md5:6665a5911f92dce1cf6d1021249af9db
   Miniconda3-4.6.14-MacOSX-x86_64.sh: md5:ffa5f0eead5576fb26b7e6902f5eed09
-
+  Miniconda2-4.7.12-Linux-x86_64.sh: md5:5a218d9dce3a77905d17ae87ac72a1e8
+  Miniconda3-4.7.12-Linux-x86_64.sh: md5:0dba759b8ecfc8948f626fa18785e3d8
+  Miniconda2-4.7.12-MacOSX-x86_64.sh: md5:2498099a426fcaafd1068fd6d79e3a6d
+  Miniconda3-4.7.12-MacOSX-x86_64.sh: md5:677f38d5ab7e1ce4fef134068e3bd76a
 
 miniconda_timeout_seconds: 600
 
@@ -54,3 +57,6 @@ miniconda_pkg_update: True
 
 # become root?
 miniconda_escalate: True
+
+# disable auto update of conda and dependencies at system level on installation/update of a package in conda environment
+miniconda_disable_auto_updates: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 dependencies:
 - role: andrewrothstein.bash
-  version: v1.1.3
+  version: v1.1.4
 - role: andrewrothstein.unarchive-deps
-  version: v1.1.0
+  version: v1.1.1
 galaxy_info:
   author: Andrew Rothstein
   company: BlackRock

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,14 @@
       args:
         creates: '{{ miniconda_install_dir }}'
 
+    - name: link miniconda...
+      become: '{{ miniconda_escalate }}'
+      become_user: root
+      file:
+        src: '{{ miniconda_install_dir }}'
+        dest: '{{ miniconda_link_dir }}'
+        state: link
+
   always:
     - name: deleting installer...
       become: '{{ miniconda_escalate }}'
@@ -53,14 +61,6 @@
       file:
         path: /tmp/{{ miniconda_installer_sh }}
         state: absent
-
-- name: link miniconda...
-  become: '{{ miniconda_escalate }}'
-  become_user: root
-  file:
-    src: '{{ miniconda_install_dir }}'
-    dest: '{{ miniconda_link_dir }}'
-    state: link
 
 - name: update conda pkgs...
   become: '{{ miniconda_escalate }}'
@@ -88,3 +88,14 @@
     src: '{{ item.f }}.j2'
     dest: '{{ item.d }}/{{ item.f }}'
     mode: '{{ item.m|default("0644") }}'
+
+- name: disable auto updates of conda and dependencies
+  when: miniconda_disable_auto_updates
+  with_items:
+    - l: 'update_dependencies: False'
+    - l: 'auto_update_conda: False'
+  lineinfile:
+    path: '/etc/conda/.condarc'
+    line: '{{ item.l }}'
+    state: present
+    create: yes

--- a/test.yml
+++ b/test.yml
@@ -4,3 +4,4 @@
     - role: '{{playbook_dir}}'
       miniconda_make_sys_default: True
       miniconda_pkg_update: False
+      miniconda_disable_auto_updates: True


### PR DESCRIPTION
Also move linking miniconda from installtion dir to `{{ miniconda_link_dir }}` as part of installation block, because if miniconda exists with different version then installation block would be skipped and link step would fail trying to link miniconda from a different version directory than installed version directory. And installation check relies on `miniconda_conda_binary.stat.exists` condition, which would be true only when `miniconda_conda_bin: '{{ miniconda_link_dir }}/bin/conda'` exists