### PR TITLE
map Darwin to MacOSX

### DIFF
--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,2 @@
+---
+miniconda_platform: 'MacOSX-{{ ansible_machine }}'


### PR DESCRIPTION
Addresses issue #17 caused by conda installer scripts referring to MacOSX rather than Darwin.
