### PR TITLE
Add `miniconda_tmp_dir` var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,5 @@ miniconda_checksums:
       MacOSX-x86_64: sha256:786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508
       # https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86_64.exe
       Windows-x86_64: sha256:b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a
+
+miniconda_tmp_dir: /tmp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,12 +42,17 @@
 
 - when: not miniconda_conda_binary.stat.exists or installed_conda_version != miniconda_ver
   block:
+    - name: ensure that {{ miniconda_tmp_dir }} directory exists
+      file:
+        path: "{{ miniconda_tmp_dir }}"
+        state: directory
+
     - name: download installer...
       become: '{{ miniconda_escalate }}'
       become_user: root
       get_url:
         url: '{{ miniconda_installer_url }}'
-        dest: /tmp/{{ miniconda_installer_sh }}
+        dest: '{{ miniconda_tmp_dir }}/{{ miniconda_installer_sh }}'
         timeout: '{{ miniconda_timeout_seconds }}'
         checksum: '{{ miniconda_checksum }}'
         mode: 0755
@@ -55,7 +60,7 @@
     - name: installing....
       become: '{{ miniconda_escalate }}'
       become_user: root
-      command: bash /tmp/{{ miniconda_installer_sh }} -b -p {{ miniconda_install_dir }}
+      shell: TMPDIR={{ miniconda_tmp_dir }} bash {{ miniconda_tmp_dir }}/{{ miniconda_installer_sh }} -b -p {{ miniconda_install_dir }}
       args:
         creates: '{{ miniconda_install_dir }}'
 
@@ -72,7 +77,7 @@
       become: '{{ miniconda_escalate }}'
       become_user: root
       file:
-        path: /tmp/{{ miniconda_installer_sh }}
+        path: '{{ miniconda_tmp_dir }}/{{ miniconda_installer_sh }}'
         state: absent
 
 - name: update conda pkgs...


### PR DESCRIPTION
This is very nice to have, because on some systems, `/tmp` is mounted with `noexec` and running the miniconda installer from it errors out with something like:

```
TASK [ansible-miniconda : installing....] *****************************************************************
fatal: [18.207.199.152]: FAILED! => {"changed": true, "cmd": [
"bash", "/tmp/Miniconda3-py39_4.10.3-Linux-x86_64.sh", "-b", 
"-p", "/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64"], "delta": "0:00:01.159150", 
"end": "2022-04-21 19:09:05.179247", "msg": "non-zero return code", "rc": 1, 
"start": "2022-04-21 19:09:04.020097", 
"stderr": "/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64/conda.exe: error while loading shared libraries: 
libz.so.1: failed to map segment from shared object: Operation not permitted\n
/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64/conda.exe: error while loading shared libraries: 
libz.so.1: failed to map segment from shared object: Operation not permitted", 
"stderr_lines": [
"/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64/conda.exe: error while loading shared libraries: 
libz.so.1: failed to map segment from shared object: Operation not permitted", 
"/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64/conda.exe: error while loading shared libraries:
 libz.so.1: failed to map segment from shared object: Operation not permitted"], 
"stdout": "PREFIX=/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64\nUnpacking payload ...", 
"stdout_lines": ["PREFIX=/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64", "Unpacking payload ..."]}
```

```
/usr/local/Miniconda3-py39_4.10.3-Linux-x86_64/conda.exe: 
error while loading shared libraries: libz.so.1: failed to map segment from shared object: 
Operation not permitted
```

The solution is to allow using a different `TMPDIR` as described at
https://stackoverflow.com/questions/60106630/conda-exe-error-while-loading-shared-libraries-libz-so-1

Without this, I get errors like the above while trying to provision an Amazon Linux EC2 instance. With this, I can put this in my playbook:

```yaml
     - name: Include ansible-miniconda role
       import_role:
         name: ansible-miniconda
       vars:
         miniconda_make_sys_default: True
         miniconda_tmp_dir: "{{ ansible_env.HOME }}/tmp"
       tags: miniconda
```

and it works.