### PR TITLE
Add `miniconda_umask`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,3 +102,10 @@ miniconda_checksums:
       Windows-x86_64: sha256:b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a
 
 miniconda_tmp_dir: /tmp
+
+# It might be necessary to change the umask on some systems, so that users
+# other than "root" can use miniconda.
+# See https://github.com/andrewrothstein/ansible-miniconda/pull/26
+#
+# miniconda_umask: '022'
+miniconda_umask: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,11 @@
     - name: installing....
       become: '{{ miniconda_escalate }}'
       become_user: root
-      shell: TMPDIR={{ miniconda_tmp_dir }} bash {{ miniconda_tmp_dir }}/{{ miniconda_installer_sh }} -b -p {{ miniconda_install_dir }}
+      shell: |
+        (
+          [ ! -z "{{ miniconda_umask }}" ] && umask {{ miniconda_umask }}
+          TMPDIR={{ miniconda_tmp_dir }} bash {{ miniconda_tmp_dir }}/{{ miniconda_installer_sh }} -b -p {{ miniconda_install_dir }}
+        )
       args:
         creates: '{{ miniconda_install_dir }}'
 
@@ -84,7 +88,11 @@
   become: '{{ miniconda_escalate }}'
   become_user: root
   when: miniconda_pkg_update
-  command: '{{ miniconda_conda_bin }} update -y --all'
+  shell: |
+    (
+      [ ! -z "{{ miniconda_umask }}" ] && umask {{ miniconda_umask }}
+      {{ miniconda_conda_bin }} update -y --all
+    )
 
 - name: remove conda-curl since it conflicts with the system curl
   when: miniconda_make_sys_default


### PR DESCRIPTION
Allow setting a custom umask, because on some systems (e.g.: an Amazon
Linux EC2 instance I'm testing with, the umask is set by default in
`/etc/profile` to `027`. This causes Miniconda to get installed with the
read and execute bits missing for world so normal users get errors when
they try to use miniconda tools.

With this, I can use:

```yaml
     - name: Include ansible-miniconda role
       include_role:
         name: ansible-miniconda
         apply:
           tags: miniconda
       vars:
         miniconda_make_sys_default: True
         miniconda_tmp_dir: "{{ ansible_env.HOME }}/tmp"
         miniconda_umask: '022'
       when: install_miniconda
       tags: miniconda
```

and Miniconda gets installed so that it can be used by any user.

Note: This branch includes #25, because it touches the same lines and separating them would lead to merge conflicts. The "real" changes for this PR are in e54effb.